### PR TITLE
Remove unnecessary JavaDoc from tutorials

### DIFF
--- a/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ArticlePage.java
+++ b/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ArticlePage.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 // START SNIPPET: tutorial
-/** A page of articles, with the pagination metadata clients need. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ListArticles.java
+++ b/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ListArticles.java
@@ -7,13 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 // START SNIPPET: tutorial
-/**
- * Lists articles, with an optional category filter.
- *
- * <p>The {@code category} query parameter is {@code required = false}. When it
- * is absent the list is unfiltered. A collection read like this has no branching
- * pipeline, so it stays a single function.
- */
 public class ListArticles {
 
 	public void service(

--- a/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ListArticlesPage.java
+++ b/tutorials/springboot/SpringRestFilterHttpServer/src/main/java/net/officefloor/tutorial/springrestfilter/ListArticlesPage.java
@@ -10,13 +10,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.util.stream.Collectors;
 
 // START SNIPPET: tutorial
-/**
- * Lists articles with the optional category filter and pagination together.
- *
- * <p>{@code category} is optional. {@code page} and {@code size} have defaults,
- * so a request needs neither. The filter and the paging combine into one
- * Spring Data query.
- */
 public class ListArticlesPage {
 
 	public void service(

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/Boom.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/Boom.java
@@ -3,11 +3,6 @@ package net.officefloor.tutorial.springrestproblemdetail;
 import net.officefloor.web.ObjectResponse;
 
 // START SNIPPET: tutorial
-/**
- * Throws an unexpected error, to show the catch-all handler. Any exception with
- * no more specific handler maps to a 500 Problem Detail that does not leak the
- * internal message.
- */
 public class Boom {
 
 	public void service(ObjectResponse<ArticleResponse> response) {

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/CreateArticle.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/CreateArticle.java
@@ -7,10 +7,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 
 // START SNIPPET: tutorial
-/**
- * Creates an article. A blank title fails {@code @Valid}, which the framework
- * reports as a MethodArgumentNotValidException, mapped to a 400 Problem Detail.
- */
 @Validated
 public class CreateArticle {
 

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/GeneralExceptionHandler.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/GeneralExceptionHandler.java
@@ -10,11 +10,6 @@ import java.net.URI;
 import java.time.Instant;
 
 // START SNIPPET: tutorial
-/**
- * Catch-all handler. Any exception with no more specific handler maps to a 500
- * Problem Detail. It uses a generic message so internal detail is never leaked
- * to the client.
- */
 public class GeneralExceptionHandler {
 
 	public void handle(@Parameter Exception ex,

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/GetArticle.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/GetArticle.java
@@ -4,12 +4,6 @@ import net.officefloor.web.ObjectResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // START SNIPPET: tutorial
-/**
- * Reads an article, or throws {@link NotFoundException} when it is absent.
- * The endpoints here are kept as single functions so the focus stays on the
- * error responses. The escalation handlers turn the thrown exceptions into
- * Problem Detail responses.
- */
 public class GetArticle {
 
 	public void service(@PathVariable(name = "id") Long id,

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/NotFoundExceptionHandler.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/NotFoundExceptionHandler.java
@@ -10,10 +10,6 @@ import java.net.URI;
 import java.time.Instant;
 
 // START SNIPPET: tutorial
-/**
- * Maps a domain {@link NotFoundException} to a 404 Problem Detail (RFC 7807).
- * The response body is an {@code application/problem+json} document.
- */
 public class NotFoundExceptionHandler {
 
 	public void handle(@Parameter NotFoundException ex,

--- a/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/ValidationExceptionHandler.java
+++ b/tutorials/springboot/SpringRestProblemDetailHttpServer/src/main/java/net/officefloor/tutorial/springrestproblemdetail/ValidationExceptionHandler.java
@@ -14,11 +14,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 // START SNIPPET: tutorial
-/**
- * Maps a framework {@link MethodArgumentNotValidException} to a 400 Problem
- * Detail, adding a field-by-field breakdown so clients can show which fields
- * failed and why.
- */
 public class ValidationExceptionHandler {
 
 	public void handle(@Parameter MethodArgumentNotValidException ex,

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/Author.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/Author.java
@@ -36,7 +36,6 @@ public class Author {
 		this.name = name;
 	}
 
-	/** Finds an article that belongs to THIS author, or null. */
 	public Article getArticle(Long articleId) {
 		for (Article article : this.articles) {
 			if (article.getId().equals(articleId)) {

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/BuildAuthorsArticle.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/BuildAuthorsArticle.java
@@ -4,11 +4,6 @@ import net.officefloor.plugin.variable.Out;
 import net.officefloor.plugin.variable.Val;
 
 // START SNIPPET: tutorial
-/**
- * Builds a new article and attaches it to the author loaded by
- * {@link LoadAuthor}. It consumes two variables: the parent author and the
- * validated request body. The author comes from the URL, not the body.
- */
 public class BuildAuthorsArticle {
 
 	public void service(@Val Author author, @Val ArticleRequest request, Out<Article> built) {

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadArticle.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadArticle.java
@@ -4,11 +4,6 @@ import net.officefloor.plugin.variable.Out;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // START SNIPPET: tutorial
-/**
- * Global load. Loads any article by id, regardless of author. Used by
- * GET /article/{articleId}. Contrast with {@link LoadAuthorsArticle}, which
- * only finds an article that belongs to a given author.
- */
 public class LoadArticle {
 
 	public void service(@PathVariable(name = "articleId") Long articleId,

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadAuthor.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadAuthor.java
@@ -4,12 +4,6 @@ import net.officefloor.plugin.variable.Out;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // START SNIPPET: tutorial
-/**
- * Shared load. This one function loads an author by id and publishes it. Every
- * author-scoped endpoint (get the author, get the author's article, create an
- * article for the author) reuses it. There is one place that turns an authorId
- * into an Author, and one place that decides a missing author is a 404.
- */
 public class LoadAuthor {
 
 	public void service(@PathVariable(name = "authorId") Long authorId,

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadAuthorsArticle.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/LoadAuthorsArticle.java
@@ -5,17 +5,6 @@ import net.officefloor.plugin.variable.Val;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // START SNIPPET: tutorial
-/**
- * Ownership-scoped load. Consumes the author loaded by {@link LoadAuthor} and
- * finds the article <em>within that author</em>. An article that exists but
- * belongs to a different author is not found, so the endpoint returns 404.
- *
- * <p>Do NOT replace this with the global {@link LoadArticle}. The global load
- * would return another author's article under
- * {@code /author/{authorId}/article/{articleId}}, which leaks data across
- * authors. The scoping is the contract of the nested URL, so the scoped load is
- * a distinct function.
- */
 public class LoadAuthorsArticle {
 
 	public void service(@Val Author author,

--- a/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/RespondWithArticle.java
+++ b/tutorials/springboot/SpringRestRelationshipHttpServer/src/main/java/net/officefloor/tutorial/springrestrelationship/RespondWithArticle.java
@@ -5,11 +5,6 @@ import net.officefloor.web.ObjectResponse;
 import org.springframework.http.ResponseEntity;
 
 // START SNIPPET: tutorial
-/**
- * Shared responder. Both GET /article/{articleId} and
- * GET /author/{authorId}/article/{articleId} reuse it, because both end with an
- * Article to render.
- */
 public class RespondWithArticle {
 
 	public void service(@Val Article article,

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ApplyArticle.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ApplyArticle.java
@@ -3,10 +3,6 @@ package net.officefloor.tutorial.springrestresolve;
 import net.officefloor.plugin.variable.Val;
 
 // START SNIPPET: tutorial
-/**
- * Applies the request to a loaded article. Like BuildArticle, it sets the
- * scalar fields only. ResolveTags handles the tag references.
- */
 public class ApplyArticle {
 
 	public void service(@Val Article article, @Val ArticleRequest request) {

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ArticleRequest.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ArticleRequest.java
@@ -17,7 +17,6 @@ public class ArticleRequest {
 	@NotBlank(message = "title is required")
 	private String title;
 
-	/** Tags are given by name. The managed Tag entities are resolved from these. */
 	private List<String> tags = new ArrayList<>();
 }
 // END SNIPPET: tutorial

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/BuildArticle.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/BuildArticle.java
@@ -4,10 +4,6 @@ import net.officefloor.plugin.variable.Out;
 import net.officefloor.plugin.variable.Val;
 
 // START SNIPPET: tutorial
-/**
- * Builds a new article from the request. It sets the scalar fields only. The
- * tags are references to other entities, so they are handled by ResolveTags.
- */
 public class BuildArticle {
 
 	public void service(@Val ArticleRequest request, Out<Article> built) {

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ResolveTags.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/ResolveTags.java
@@ -5,19 +5,6 @@ import net.officefloor.plugin.variable.Val;
 import java.util.List;
 
 // START SNIPPET: tutorial
-/**
- * Resolve function. It enriches the article by looking up the managed Tag
- * entities named in the request and setting them on the article.
- *
- * <p>It is an action, like Apply, but it does a repository lookup rather than
- * copying a field. It runs after Build or Apply and before Save. It mutates the
- * article's tag collection in place, so the following Save persists the managed
- * references. The same function serves both the create and the update pipeline.
- *
- * <p>Mutating the collection in place (clear then add) rather than replacing it
- * keeps the managed entity's collection tracked by the persistence context.
- * The looked-up tags are already managed, so nothing transient is ever saved.
- */
 public class ResolveTags {
 
 	public void service(@Val Article article, @Val ArticleRequest request,

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/Tag.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/main/java/net/officefloor/tutorial/springrestresolve/Tag.java
@@ -8,10 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 // START SNIPPET: tutorial
-/**
- * Reference entity. Tags are shared across articles and are looked up by name.
- * They are pre-seeded (see data.sql), not created per request.
- */
 @Entity
 @Table(name = "tags")
 public class Tag {

--- a/tutorials/springboot/SpringRestResolveHttpServer/src/test/java/net/officefloor/tutorial/springrestresolve/ResolveTagsUnitTest.java
+++ b/tutorials/springboot/SpringRestResolveHttpServer/src/test/java/net/officefloor/tutorial/springrestresolve/ResolveTagsUnitTest.java
@@ -12,10 +12,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 // START SNIPPET: tutorial
-/**
- * ResolveTags takes the entity, the request and a repository, no Out. So it
- * unit tests with plain objects and a stubbed repository. No Spring, no server.
- */
 public class ResolveTagsUnitTest {
 
 	@Test

--- a/tutorials/springboot/SpringRestTestingHttpServer/src/test/java/net/officefloor/tutorial/springresttesting/ArticleEndpointIntegrationTest.java
+++ b/tutorials/springboot/SpringRestTestingHttpServer/src/test/java/net/officefloor/tutorial/springresttesting/ArticleEndpointIntegrationTest.java
@@ -14,11 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 // START SNIPPET: tutorial
-/**
- * One integration test for what the unit tests cannot cover: the wiring.
- * The order of the functions, the @Valid binding, and the escalation routing
- * are framework behaviour, so they are proven through the running application.
- */
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ArticleEndpointIntegrationTest {

--- a/tutorials/springboot/SpringRestTestingHttpServer/src/test/java/net/officefloor/tutorial/springresttesting/ArticleFunctionUnitTest.java
+++ b/tutorials/springboot/SpringRestTestingHttpServer/src/test/java/net/officefloor/tutorial/springresttesting/ArticleFunctionUnitTest.java
@@ -16,11 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 // START SNIPPET: tutorial
-/**
- * Unit tests for individual functions. No Spring context, no server, no HTTP.
- * Each function is a plain object: construct it, call the one method, assert.
- * These run in milliseconds.
- */
 public class ArticleFunctionUnitTest {
 
 	// A pure function: no dependencies at all. Just logic over two values.


### PR DESCRIPTION
Remove unnecessary JavaDoc to make tutorial code more concise leaving tutorials content to explain